### PR TITLE
💚 Fix #27

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,10 +1,8 @@
 name: Continuous Deployment
 on:
-  workflow_run:
-    workflows: ["CI tests"]
-    types:
-      - completed
-    # Remove the branches filter from here
+  push:
+    branches:
+      - main # main 브랜치로의 모든 push 이벤트 (PR 병합 포함) 에 실행
 
 permissions:
   contents: write
@@ -12,8 +10,6 @@ permissions:
 
 jobs:
   deploy:
-    # Update the condition to check both success and target branch
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: windows-2022
 
     steps:


### PR DESCRIPTION
This pull request updates the `.github/workflows/cd.yaml` file to modify the trigger mechanism for the Continuous Deployment workflow. The workflow now runs on push events to the `main` branch instead of being triggered by the completion of another workflow.

Workflow trigger updates:

* Changed the trigger from `workflow_run` (dependent on the completion of "CI tests") to `push` events targeting the `main` branch. This ensures the workflow runs for all push events to `main`, including PR merges.